### PR TITLE
ci: skillx failure should not fail the job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
             export WRITE_API_ENDPOINT=${KV_URL}
             export ADMIN_TOKEN=${KV_AUTH}
             export DATA_PREFIX="HSM_"
-            bash backend/scripts/uploadSkillx.sh $(realpath masterdata/Skill.json)
+            bash backend/scripts/uploadSkillx.sh $(realpath masterdata/Skill.json) || true
 
 workflows:
   run-scenarios:


### PR DESCRIPTION
The ugly way seems to be needed since CircleCI does not have something like GitHub Action's [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error=)...