### PR TITLE
chore: use pnpm@8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           command: |
             git clone https://github.com/MalitsPlus/IDOLY-Backend.git backend
             cd backend
-            npx pnpm@7 install
+            npx pnpm@8 install
       - run:
           name: Generate and upload Skillx
           command: |


### PR DESCRIPTION
We've upgraded `pnpm-lock.yaml` at IDOLY-Backend to `pnpm@8` (MalitsPlus/IDOLY-Backend@f39266e16ff7a78182d201e1d818586c3504f326).